### PR TITLE
Fix(inventory): Remove faulty duplication check

### DIFF
--- a/src/main/java/com/minekarta/advancedcorehub/manager/InventoryManager.java
+++ b/src/main/java/com/minekarta/advancedcorehub/manager/InventoryManager.java
@@ -90,13 +90,9 @@ public class InventoryManager {
             // --- Give Item ---
             int amount = itemData.get("amount") != null ? (int) itemData.get("amount") : 1;
             int slot = itemData.get("slot") != null ? (int) itemData.get("slot") : -1;
-            boolean force = itemData.get("force") != null ? (boolean) itemData.get("force") : false;
 
-            // Prevent item duplication if not forced
-            if (!force && player.getInventory().contains(plugin.getItemsManager().getItem(itemName))) {
-                continue;
-            }
-
+            // The duplication check was removed as it was redundant after clearing the inventory
+            // and was likely causing issues with ItemStack equality checks, preventing items from being given.
             plugin.getItemsManager().giveItem(player, itemName, amount, slot);
         }
     }


### PR DESCRIPTION
Removes the item duplication check in the `giveJoinItems` method. This check was redundant because the inventory is cleared before items are given.

The `ItemStack.contains()` check was likely failing due to issues with `ItemStack` equality on custom items, preventing players from receiving their hotbar items and rendering them 'useless'.