### PR TITLE
Fix: Load gadgets.yml to prevent NullPointerException

### DIFF
--- a/src/main/java/com/minekarta/advancedcorehub/manager/FileManager.java
+++ b/src/main/java/com/minekarta/advancedcorehub/manager/FileManager.java
@@ -35,6 +35,7 @@ public class FileManager {
         // Load other configs
         loadConfigFile("items.yml");
         loadConfigFile("cosmetics.yml");
+        loadConfigFile("gadgets.yml");
         loadConfigFile("menus/selector.yml");
         loadConfigFile("menus/socials.yml");
         loadConfigFile("menus/vip_gadget.yml");


### PR DESCRIPTION
The `gadgets.yml` configuration file was not being loaded by the `FileManager` during the plugin's startup sequence. This caused a `NullPointerException` in `GadgetManager` when it tried to access the configuration, as `getConfig("gadgets.yml")` returned null.

This commit resolves the issue by adding `loadConfigFile("gadgets.yml")` to the `FileManager.setup()` method, ensuring the file is loaded correctly before it is accessed.