### PR TITLE
feat: Add missing features from DeluxeHub

### DIFF
--- a/src/main/java/com/minekarta/advancedcorehub/AdvancedCoreHub.java
+++ b/src/main/java/com/minekarta/advancedcorehub/AdvancedCoreHub.java
@@ -28,6 +28,7 @@ public class AdvancedCoreHub extends JavaPlugin {
     private ServerInfoManager serverInfoManager;
     private CosmeticsManager cosmeticsManager;
     private GadgetManager gadgetManager;
+    private PlayerVisibilityManager playerVisibilityManager;
 
 
     @Override
@@ -62,6 +63,7 @@ public class AdvancedCoreHub extends JavaPlugin {
         this.cosmeticsManager = new CosmeticsManager(this);
         this.gadgetManager = new GadgetManager(this);
         this.gadgetManager.loadGadgets();
+        this.playerVisibilityManager = new PlayerVisibilityManager(this);
 
 
         // Load other components
@@ -119,11 +121,33 @@ public class AdvancedCoreHub extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ItemProtectionListener(this), this);
         getServer().getPluginManager().registerEvents(new PlayerQuitListener(this), this);
         getServer().getPluginManager().registerEvents(new PlayerMoveListener(this), this);
+
+        // Register Double Jump Listener if enabled
+        if (getConfig().getBoolean("double_jump.enabled", false)) {
+            getServer().getPluginManager().registerEvents(new DoubleJumpListener(this), this);
+            getLogger().info("Double Jump feature enabled.");
+        }
+
+        // Register Chat Protection Listener if either feature is enabled
+        if (getConfig().getBoolean("chat_protection.anti_swear.enabled", false) ||
+            getConfig().getBoolean("chat_protection.command_blocker.enabled", false)) {
+            getServer().getPluginManager().registerEvents(new ChatProtectionListener(this), this);
+            getLogger().info("Chat Protection feature enabled.");
+        }
     }
 
     private void registerChannels() {
         this.getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
         this.getServer().getMessenger().registerIncomingPluginChannel(this, "BungeeCord", this.serverInfoManager);
+
+        // Register Anti-World Downloader channels if enabled
+        if (getConfig().getBoolean("anti_world_downloader.enabled", true)) {
+            AntiWorldDownloaderListener wdlListener = new AntiWorldDownloaderListener(this);
+            this.getServer().getMessenger().registerIncomingPluginChannel(this, "WDL|INIT", wdlListener);
+            this.getServer().getMessenger().registerIncomingPluginChannel(this, "WDL|REQUEST", wdlListener);
+            this.getServer().getMessenger().registerIncomingPluginChannel(this, "worlddownloader:init", wdlListener);
+            getLogger().info("Anti-World Downloader feature enabled.");
+        }
     }
 
     // --- Getters ---
@@ -186,5 +210,9 @@ public class AdvancedCoreHub extends JavaPlugin {
 
     public GadgetManager getGadgetManager() {
         return gadgetManager;
+    }
+
+    public PlayerVisibilityManager getPlayerVisibilityManager() {
+        return playerVisibilityManager;
     }
 }

--- a/src/main/java/com/minekarta/advancedcorehub/listeners/AntiWorldDownloaderListener.java
+++ b/src/main/java/com/minekarta/advancedcorehub/listeners/AntiWorldDownloaderListener.java
@@ -1,0 +1,26 @@
+package com.minekarta.advancedcorehub.listeners;
+
+import com.minekarta.advancedcorehub.AdvancedCoreHub;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.jetbrains.annotations.NotNull;
+
+public class AntiWorldDownloaderListener implements PluginMessageListener {
+
+    private final AdvancedCoreHub plugin;
+
+    public AntiWorldDownloaderListener(AdvancedCoreHub plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, @NotNull byte[] message) {
+        // The content of the message doesn't matter, just the fact that we received it.
+        // We run this on the main server thread to ensure thread safety with the Bukkit API.
+        plugin.getServer().getScheduler().runTask(plugin, () -> {
+            String kickMessage = plugin.getLocaleManager().getString("anti_wdl_kick_message", player);
+            player.kickPlayer(kickMessage);
+            plugin.getLogger().info("Kicked player " + player.getName() + " for using a World Downloader mod (channel: " + channel + ").");
+        });
+    }
+}

--- a/src/main/java/com/minekarta/advancedcorehub/listeners/ChatProtectionListener.java
+++ b/src/main/java/com/minekarta/advancedcorehub/listeners/ChatProtectionListener.java
@@ -1,0 +1,80 @@
+package com.minekarta.advancedcorehub.listeners;
+
+import com.minekarta.advancedcorehub.AdvancedCoreHub;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ChatProtectionListener implements Listener {
+
+    private final AdvancedCoreHub plugin;
+    private final List<String> blockedWords;
+    private final List<String> blockedCommands;
+
+    public ChatProtectionListener(AdvancedCoreHub plugin) {
+        this.plugin = plugin;
+        // Load and lowercase the lists for case-insensitive matching
+        this.blockedWords = plugin.getConfig().getStringList("chat_protection.anti_swear.blocked_words")
+                .stream()
+                .map(String::toLowerCase)
+                .collect(Collectors.toList());
+        this.blockedCommands = plugin.getConfig().getStringList("chat_protection.command_blocker.blocked_commands")
+                .stream()
+                .map(String::toLowerCase)
+                .collect(Collectors.toList());
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerChat(AsyncPlayerChatEvent event) {
+        if (!plugin.getConfig().getBoolean("chat_protection.anti_swear.enabled", false)) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        if (player.hasPermission("advancedcorehub.bypass.antiswear")) {
+            return;
+        }
+
+        String message = event.getMessage().toLowerCase();
+        for (String blockedWord : blockedWords) {
+            if (message.contains(blockedWord)) {
+                event.setCancelled(true);
+                plugin.getLocaleManager().sendMessage(player, "chat-protection-swear-warning");
+                return;
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerCommand(PlayerCommandPreprocessEvent event) {
+        if (!plugin.getConfig().getBoolean("chat_protection.command_blocker.enabled", false)) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        if (player.hasPermission("advancedcorehub.bypass.commandblocker")) {
+            return;
+        }
+
+        String command = event.getMessage().toLowerCase().substring(1); // remove leading '/'
+        // Handle commands with namespace, e.g. /minecraft:me
+        if (command.contains(":")) {
+            command = command.split(":")[1];
+        }
+        final String finalCommand = command;
+
+        for (String blockedCommand : blockedCommands) {
+            if (finalCommand.startsWith(blockedCommand)) {
+                event.setCancelled(true);
+                plugin.getLocaleManager().sendMessage(player, "chat-protection-command-warning");
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/com/minekarta/advancedcorehub/listeners/DoubleJumpListener.java
+++ b/src/main/java/com/minekarta/advancedcorehub/listeners/DoubleJumpListener.java
@@ -1,0 +1,72 @@
+package com.minekarta.advancedcorehub.listeners;
+
+import com.minekarta.advancedcorehub.AdvancedCoreHub;
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerToggleFlightEvent;
+import org.bukkit.util.Vector;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class DoubleJumpListener implements Listener {
+
+    private final AdvancedCoreHub plugin;
+    private final Map<UUID, Long> cooldowns = new HashMap<>();
+
+    public DoubleJumpListener(AdvancedCoreHub plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onPlayerToggleFlight(PlayerToggleFlightEvent event) {
+        Player player = event.getPlayer();
+
+        // Ensure this feature only works in configured hub worlds
+        if (!plugin.getHubWorlds().contains(player.getWorld().getName())) {
+            return;
+        }
+
+        // Feature disabled or player in creative/spectator
+        if (!plugin.getConfig().getBoolean("double_jump.enabled", false) ||
+            player.getGameMode() == GameMode.CREATIVE ||
+            player.getGameMode() == GameMode.SPECTATOR) {
+            return;
+        }
+
+        // Prevent double jump from interfering with actual flight
+        if (player.getAllowFlight()) {
+            return;
+        }
+
+        event.setCancelled(true);
+
+        // Cooldown check
+        long cooldownTime = plugin.getConfig().getLong("double_jump.cooldown", 2) * 1000;
+        if (cooldowns.containsKey(player.getUniqueId())) {
+            long secondsLeft = ((cooldowns.get(player.getUniqueId()) + cooldownTime) - System.currentTimeMillis()) / 1000;
+            if (secondsLeft > 0) {
+                // Optionally send a message to the player
+                // plugin.getLanguageManager().sendMessage(player, "double_jump_cooldown", "{time}", String.valueOf(secondsLeft));
+                return;
+            }
+        }
+
+        // Apply the double jump velocity
+        double power = plugin.getConfig().getDouble("double_jump.power", 1.2);
+        Vector jumpVector = player.getLocation().getDirection().multiply(0.1).setY(power);
+        player.setVelocity(jumpVector);
+
+        // Play a sound
+        String soundName = plugin.getConfig().getString("double_jump.sound.name", "ENTITY_FIREWORK_ROCKET_LAUNCH");
+        float volume = (float) plugin.getConfig().getDouble("double_jump.sound.volume", 1.0);
+        float pitch = (float) plugin.getConfig().getDouble("double_jump.sound.pitch", 1.0);
+        player.playSound(player.getLocation(), soundName, volume, pitch);
+
+        // Set cooldown
+        cooldowns.put(player.getUniqueId(), System.currentTimeMillis());
+    }
+}

--- a/src/main/java/com/minekarta/advancedcorehub/listeners/PlayerJoinListener.java
+++ b/src/main/java/com/minekarta/advancedcorehub/listeners/PlayerJoinListener.java
@@ -117,5 +117,8 @@ public class PlayerJoinListener implements Listener {
                 }, remainingTicks);
             }
         }
+
+        // 6. Handle Player Visibility
+        plugin.getPlayerVisibilityManager().handlePlayerJoin(player);
     }
 }

--- a/src/main/java/com/minekarta/advancedcorehub/manager/ActionManager.java
+++ b/src/main/java/com/minekarta/advancedcorehub/manager/ActionManager.java
@@ -78,6 +78,7 @@ public class ActionManager {
         registerAction("GAMEMODE", new GamemodeAction(plugin));
         registerAction("MOVEMENT", new MovementAction(plugin));
         registerAction("MESSAGE", new MessageAction(plugin));
+        registerAction("TOGGLE_VISIBILITY", (player, data) -> plugin.getPlayerVisibilityManager().togglePlayerVisibility(player));
     }
 
     public void registerAction(String identifier, Action action) {

--- a/src/main/java/com/minekarta/advancedcorehub/manager/PlayerVisibilityManager.java
+++ b/src/main/java/com/minekarta/advancedcorehub/manager/PlayerVisibilityManager.java
@@ -1,0 +1,61 @@
+package com.minekarta.advancedcorehub.manager;
+
+import com.minekarta.advancedcorehub.AdvancedCoreHub;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class PlayerVisibilityManager {
+
+    private final AdvancedCoreHub plugin;
+    private final Set<UUID> hidingPlayers = new HashSet<>();
+
+    public PlayerVisibilityManager(AdvancedCoreHub plugin) {
+        this.plugin = plugin;
+    }
+
+    public boolean isHidingPlayers(Player player) {
+        return hidingPlayers.contains(player.getUniqueId());
+    }
+
+    public void togglePlayerVisibility(Player player) {
+        if (isHidingPlayers(player)) {
+            showAllPlayers(player);
+        } else {
+            hideAllPlayers(player);
+        }
+    }
+
+    public void hideAllPlayers(Player player) {
+        hidingPlayers.add(player.getUniqueId());
+        for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+            if (!player.equals(onlinePlayer)) {
+                player.hidePlayer(plugin, onlinePlayer);
+            }
+        }
+        plugin.getLocaleManager().sendMessage(player, "player-hider-hidden");
+    }
+
+    public void showAllPlayers(Player player) {
+        hidingPlayers.remove(player.getUniqueId());
+        for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+            if (!player.equals(onlinePlayer)) {
+                player.showPlayer(plugin, onlinePlayer);
+            }
+        }
+        plugin.getLocaleManager().sendMessage(player, "player-hider-shown");
+    }
+
+    public void handlePlayerJoin(Player joinedPlayer) {
+        // Hide the newly joined player from anyone who has hiding enabled
+        for (UUID hidingPlayerUUID : hidingPlayers) {
+            Player hidingPlayer = Bukkit.getPlayer(hidingPlayerUUID);
+            if (hidingPlayer != null) {
+                hidingPlayer.hidePlayer(plugin, joinedPlayer);
+            }
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -53,6 +53,34 @@ world_settings:
   cancel_hunger_loss: true
   cancel_weather_change: true
 
+# --- Chat Protection ---
+# Settings for anti-swear and command blocking.
+chat_protection:
+  anti_swear:
+    enabled: true
+    # A list of words to block in chat. Not case-sensitive.
+    blocked_words:
+      - "badword1"
+      - "example"
+      - "swear"
+  command_blocker:
+    enabled: true
+    # A list of commands to block. Do not include the leading '/'.
+    # This will block '/plugins' and '/pl', and also variants like '/bukkit:plugins'.
+    blocked_commands:
+      - "plugins"
+      - "pl"
+      - "ver"
+      - "version"
+      - "?"
+      - "about"
+      - "icanhasbukkit"
+
+# --- Anti World Downloader ---
+# Prevents players from using World Downloader mods.
+anti_world_downloader:
+  enabled: true
+
 # --- Inventory Management ---
 # Settings for how inventories are handled in hub worlds.
 inventory_management:
@@ -89,6 +117,19 @@ movement_items:
   custom_elytra:
     cooldown: 10
     speed_boost: 1.8
+
+# Settings for the Double Jump feature.
+double_jump:
+  enabled: true
+  # Cooldown in seconds between each double jump.
+  cooldown: 2
+  # The vertical power of the jump.
+  power: 1.2
+  # Sound played on double jump.
+  sound:
+    name: "ENTITY_FIREWORK_ROCKET_LAUNCH"
+    volume: 1.0
+    pitch: 1.0
 
 # ----------------------------------------------------------------
 # Automatic Announcements

--- a/src/main/resources/items.yml
+++ b/src/main/resources/items.yml
@@ -71,11 +71,26 @@ items:
       - "[MENU] vip_gadget"
     protected: true
 
+  player_hider:
+    material: LIME_DYE
+    displayname: "<green>Players: Visible <gray>(Click)"
+    lore:
+      - "<gray>Click to hide other players."
+    custom-model-data: 101
+    # Note: A more advanced implementation would change the material/name
+    # based on the current state (e.g., to RED_DYE and "Players: Hidden").
+    # This requires custom logic beyond the scope of a simple action.
+    right-click-actions:
+      - "[TOGGLE_VISIBILITY]"
+    protected: true
+
 # This section defines items to be given to players when they join.
 # 'item_name' must match an ID from the 'items' section above.
 join_items:
   - item_name: server_selector
     slot: 0
+  - item_name: player_hider
+    slot: 2
   - item_name: profile_menu
     slot: 8
   - item_name: vip_gadget

--- a/src/main/resources/languages/en.yml
+++ b/src/main/resources/languages/en.yml
@@ -59,3 +59,14 @@ bossbar-removed: "<green>Boss bar removed for <yellow>{0}</yellow>."
 bossbar-set-success: "<green>Boss bar <yellow>{0}</yellow> set to <yellow>{1}</yellow> for <yellow>{2}</yellow>."
 bossbar-invalid-color: "<red>Invalid color: <yellow>{0}</yellow>. Valid colors are: PINK, BLUE, RED, GREEN, YELLOW, PURPLE, WHITE."
 bossbar-invalid-style: "<red>Invalid style: <yellow>{0}</yellow>. Valid styles are: SOLID, SEGMENTED_6, SEGMENTED_10, SEGMENTED_12, SEGMENTED_20."
+
+# Anti-World Downloader
+anti_wdl_kick_message: "<red>Using a World Downloader mod is not allowed on this server."
+
+# Chat Protection
+chat-protection-swear-warning: "<red>Your message contains a blocked word."
+chat-protection-command-warning: "<red>You are not allowed to use this command."
+
+# Player Hider
+player-hider-hidden: "<green>Players are now hidden."
+player-hider-shown: "<green>Players are now visible."


### PR DESCRIPTION
This commit implements several features that were present in DeluxeHub but missing in AdvancedCoreHub, as requested by the user. All features are implemented in a professional, modular, and configurable way that integrates seamlessly with the existing plugin architecture.

New Features:
- Double Jump: Allows players to jump a second time in mid-air. Fully configurable (power, cooldown, sound) and only active in hub worlds.
- Player Hider: Implemented via a new `[TOGGLE_VISIBILITY]` action and a corresponding item. Hides/shows other players and handles new players joining correctly.
- Chat Protection: Includes an anti-swear filter and a command blocker. Both are configurable with custom word/command lists.
- Anti-World Downloader: Prevents players from using world downloader mods by listening for their plugin channels and kicking them.

All user-facing messages for these new features have been added to the `en.yml` language file. Listeners are registered conditionally based on settings in `config.yml` to ensure efficiency.