### PR TITLE
Fix: Corrected the channel name separator to prevent a server crash.

### DIFF
--- a/src/main/java/com/minekarta/advancedcorehub/AdvancedCoreHub.java
+++ b/src/main/java/com/minekarta/advancedcorehub/AdvancedCoreHub.java
@@ -143,8 +143,8 @@ public class AdvancedCoreHub extends JavaPlugin {
         // Register Anti-World Downloader channels if enabled
         if (getConfig().getBoolean("anti_world_downloader.enabled", true)) {
             AntiWorldDownloaderListener wdlListener = new AntiWorldDownloaderListener(this);
-            this.getServer().getMessenger().registerIncomingPluginChannel(this, "WDL|INIT", wdlListener);
-            this.getServer().getMessenger().registerIncomingPluginChannel(this, "WDL|REQUEST", wdlListener);
+            this.getServer().getMessenger().registerIncomingPluginChannel(this, "wdl:init", wdlListener);
+            this.getServer().getMessenger().registerIncomingPluginChannel(this, "wdl:request", wdlListener);
             this.getServer().getMessenger().registerIncomingPluginChannel(this, "worlddownloader:init", wdlListener);
             getLogger().info("Anti-World Downloader feature enabled.");
         }


### PR DESCRIPTION
The plugin was using a `|` as a separator in the channel name, which is not supported by the Bukkit API. This caused a `java.lang.IllegalArgumentException` on server startup.

This commit replaces the `|` with a `:` in the channel names `WDL|INIT` and `WDL|REQUEST`, and also converts them to lowercase to align with the existing `worlddownloader:init` channel.