### PR TITLE
Fix(pom): Remove restrictive includes from compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,6 @@
                     <compilerArgs>
                         <arg>-parameters</arg>
                     </compilerArgs>
-                    <includes>
-                        <include>**/PlaceholderManager.java</include>
-                    </includes>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The `maven-compiler-plugin` was configured to only include `PlaceholderManager.java` in the compilation. This caused the main class, `AdvancedCoreHub.java`, and all other classes to be excluded from the final JAR, resulting in a `ClassNotFoundException` when the server tried to load the plugin.

This commit removes the `<includes>` section from the `maven-compiler-plugin` configuration, allowing all source files to be compiled as expected.