### PR TITLE
Fix(Manager): Resolve NullPointerException in LocaleManager

### DIFF
--- a/src/main/java/com/minekarta/advancedcorehub/manager/FileManager.java
+++ b/src/main/java/com/minekarta/advancedcorehub/manager/FileManager.java
@@ -41,7 +41,8 @@ public class FileManager {
         loadAllConfigsFromFolder("menus");
 
         // Load language files
-        loadAllConfigsFromFolder("languages");
+        loadConfigFile("languages/en.yml");
+        loadConfigFile("languages/pt.yml");
     }
 
     public void loadConfigFile(String fileName) {


### PR DESCRIPTION
The LocaleManager was throwing a NullPointerException during PlayerJoinEvent and on some commands because the language files (e.g., en.yml) were not being loaded correctly.

The `FileManager`'s `loadAllConfigsFromFolder` method did not properly save the default language files from the JAR into the plugin's data folder on first startup. This resulted in the `langFile` configuration object being null when accessed.

This fix replaces the unreliable folder-loading logic for languages with explicit calls to `loadConfigFile` for each language file (`languages/en.yml` and `languages/pt.yml`). The `loadConfigFile` method already contains the necessary logic to save the resource from the JAR if it doesn't exist on disk, ensuring the language files are always available.