### PR TITLE
fix(filemanager): Use jar: URI scheme to access JAR resources

### DIFF
--- a/src/main/java/com/minekarta/advancedcorehub/manager/FileManager.java
+++ b/src/main/java/com/minekarta/advancedcorehub/manager/FileManager.java
@@ -92,12 +92,13 @@ public class FileManager {
     private void loadAllConfigsFromFolder(String folderName) {
         // Discover and load default configs from the JAR. This copies them to the data folder if they don't exist.
         try {
-            URI uri = plugin.getClass().getProtectionDomain().getCodeSource().getLocation().toURI();
+            URI codeSourceUri = plugin.getClass().getProtectionDomain().getCodeSource().getLocation().toURI();
+            URI jarUri = URI.create("jar:" + codeSourceUri.toString());
             FileSystem fileSystem;
             try {
-                fileSystem = FileSystems.getFileSystem(uri);
+                fileSystem = FileSystems.getFileSystem(jarUri);
             } catch (FileSystemNotFoundException e) {
-                fileSystem = FileSystems.newFileSystem(Paths.get(uri), Collections.emptyMap());
+                fileSystem = FileSystems.newFileSystem(jarUri, Collections.emptyMap());
             }
 
             Path folderPathInJar = fileSystem.getPath(folderName);


### PR DESCRIPTION
The plugin was failing to load configs from the 'menus' folder inside the JAR because it was using a 'file:' URI instead of a 'jar:' URI to access the JAR's contents.

This caused a 'java.lang.IllegalArgumentException: Path component should be '/'' on some systems.

This commit corrects the URI scheme, ensuring that the JAR's internal file system is accessed correctly.