### PR TITLE
Fix various warnings and bugs in the plugin

### DIFF
--- a/src/main/java/com/minekarta/advancedcorehub/util/ItemBuilder.java
+++ b/src/main/java/com/minekarta/advancedcorehub/util/ItemBuilder.java
@@ -26,15 +26,15 @@ public class ItemBuilder {
     private static final Logger LOGGER = Bukkit.getLogger();
 
     public ItemBuilder(String materialString) {
-        if (hdbApi == null && Bukkit.getPluginManager().isPluginEnabled("HeadDatabase")) {
-            hdbApi = new HeadDatabaseAPI();
-        }
-
         String lowerMaterialString = materialString.toLowerCase();
 
         if (lowerMaterialString.startsWith("headdatabase:") || lowerMaterialString.startsWith("hdb:")) {
+            if (hdbApi == null && Bukkit.getPluginManager().isPluginEnabled("HeadDatabase")) {
+                hdbApi = new HeadDatabaseAPI();
+            }
+
             if (hdbApi == null) {
-                LOGGER.warning("HeadDatabase is not enabled, but an item tried to use it. Defaulting to PLAYER_HEAD.");
+                LOGGER.warning("Tried to use a HeadDatabase item, but the HeadDatabase plugin is not enabled. Defaulting to PLAYER_HEAD.");
                 this.itemStack = new ItemStack(Material.PLAYER_HEAD);
             } else {
                 try {


### PR DESCRIPTION
This commit addresses several warnings that were appearing in the server logs:

1.  **Fix `FireworkAction` data type error:** The `ActionManager` was incorrectly passing a `List<String>` to default actions that expected a `String`. This has been fixed by differentiating between default and custom actions and passing the appropriate data type to each. A comment has been added to clarify this logic.

2.  **Add `LANG` action alias:** The "Unknown action identifier: LANG" warning is resolved by registering `LANG` as an alias for the `MESSAGE` action.

3.  **Improve `HeadDatabase` logic:** The "HeadDatabase is not enabled" warning has been addressed by making the API initialization lazy (on-demand) and improving the warning message to be more descriptive.