### PR TITLE
Fix(hotbar): Repair menu actions and center server selector

### DIFF
--- a/src/main/java/com/minekarta/advancedcorehub/actions/types/MenuAction.java
+++ b/src/main/java/com/minekarta/advancedcorehub/actions/types/MenuAction.java
@@ -16,12 +16,10 @@ public class MenuAction implements Action {
 
     @Override
     public void execute(Player player, Object data) {
-        if (!(data instanceof List)) return;
-        @SuppressWarnings("unchecked")
-        List<String> args = (List<String>) data;
-        if (args.size() < 2) return;
+        if (!(data instanceof String)) return;
+        String menuName = (String) data;
+        if (menuName.isEmpty()) return;
 
-        String menuName = args.get(1).trim();
-        plugin.getMenuManager().openMenu(player, menuName);
+        plugin.getMenuManager().openMenu(player, menuName.trim());
     }
 }

--- a/src/main/resources/items.yml
+++ b/src/main/resources/items.yml
@@ -77,7 +77,7 @@ items:
 # 'item_name' must match an ID from the 'items' section above.
 join_items:
   - item_name: server_selector
-    slot: 0
+    slot: 4
   - item_name: player_hider
     slot: 2
   - item_name: profile_menu


### PR DESCRIPTION
This commit addresses two issues with the hotbar items:

1.  The server selector and profile menu items were not functional. This was caused by an incorrect implementation in the `MenuAction` class, which was expecting a `List` of arguments instead of a `String`. The `ActionManager` is designed to pass a simple `String` to all default actions. The `MenuAction` has been updated to correctly handle a `String` argument, bringing it in line with the action framework's design and restoring the functionality of menu-opening items.

2.  The server selector item was positioned at the far left of the hotbar (slot 0). The user requested it to be in the middle. The `items.yml` configuration has been updated to place the `server_selector` in slot 4, the central position in the hotbar.