### PR TITLE
Fix ResourceLocationException for menu open sound

### DIFF
--- a/src/main/java/com/minekarta/advancedcorehub/manager/MenuManager.java
+++ b/src/main/java/com/minekarta/advancedcorehub/manager/MenuManager.java
@@ -53,7 +53,7 @@ public class MenuManager {
         // Play the open sound, if configured
         ConfigurationSection openSoundSection = plugin.getConfig().getConfigurationSection("menu_sounds.open");
         if (openSoundSection != null && openSoundSection.getBoolean("enabled", false)) {
-            String soundName = openSoundSection.getString("name", "ENTITY_CHICKEN_EGG");
+            String soundName = openSoundSection.getString("name", "ENTITY_CHICKEN_EGG").toLowerCase();
             float volume = (float) openSoundSection.getDouble("volume", 1.0);
             float pitch = (float) openSoundSection.getDouble("pitch", 1.0);
             player.playSound(player.getLocation(), soundName, volume, pitch);


### PR DESCRIPTION
The menu open sound was causing a `net.minecraft.ResourceLocationException` because the sound name from the configuration could be in uppercase, while Minecraft's resource location system requires lowercase.

This commit fixes the issue by converting the sound name to lowercase before it is used to play the sound. This ensures that the resource location is always valid.