### PR TITLE
Fix invalid click sound name for menu interactions

### DIFF
--- a/src/main/java/com/minekarta/advancedcorehub/listeners/MenuListener.java
+++ b/src/main/java/com/minekarta/advancedcorehub/listeners/MenuListener.java
@@ -69,7 +69,7 @@ public class MenuListener implements Listener {
             // Play the click sound, if configured
             ConfigurationSection clickSoundSection = plugin.getConfig().getConfigurationSection("menu_sounds.click");
             if (clickSoundSection != null && clickSoundSection.getBoolean("enabled", false)) {
-                String soundName = clickSoundSection.getString("name", "UI_BUTTON_CLICK");
+                String soundName = clickSoundSection.getString("name", "ui.button.click");
                 float volume = (float) clickSoundSection.getDouble("volume", 1.0);
                 float pitch = (float) clickSoundSection.getDouble("pitch", 1.0);
                 player.playSound(player.getLocation(), soundName, volume, pitch);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -143,7 +143,7 @@ menu_sounds:
   # Sound played when a player clicks any item in a menu.
   click:
     enabled: true
-    name: "UI_BUTTON_CLICK"
+    name: "ui.button.click"
     volume: 1.0
     pitch: 1.0
 


### PR DESCRIPTION
The sound name 'UI_BUTTON_CLICK' is not a valid Minecraft resource location because it contains uppercase characters. This was causing a `ResourceLocationException` when players clicked in menus.

This commit fixes the issue by:
1. Changing the default sound name in `MenuListener.java` to the correct `ui.button.click`.
2. Updating the default `config.yml` to use the correct `ui.button.click` sound name.