### PR TITLE
Fix UnsatisfiedLinkError for SQLite native library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,9 @@
                         <relocation>
                             <pattern>org.sqlite</pattern>
                             <shadedPattern>com.minekarta.advancedcorehub.lib.sqlite</shadedPattern>
+                            <excludes>
+                                <exclude>org.sqlite.native.**</exclude>
+                            </excludes>
                         </relocation>
                     </relocations>
                     <filters>


### PR DESCRIPTION
The `UnsatisfiedLinkError` was caused by the `maven-shade-plugin` relocating the native library packages for `sqlite-jdbc`. This prevented the Java Native Interface (JNI) from finding the required native code at runtime.

To fix this, I've excluded the `org.sqlite.native.**` package from the relocation process in the `pom.xml`. This ensures that the native libraries remain at their original paths within the shaded JAR, allowing them to be loaded correctly.